### PR TITLE
Added usage guidance and info about paid developer features

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -7,6 +7,7 @@ permalink: /
 This site hosts the documentation for the University of Colorado's GitHub Enterprise agreement. Each campus manages it's own GitHub organization, however the core of GitHub Enterprise is managed by the Platform Engineering team at the University of Colorado Boulder. If you wish to contact the Platform Engineering team please [email us](mailto:help@colorado.edu?subject=[GitHub]%20Route%20to%20Platform%20Engineering).
 
 ## For End Users
+- [Usage Guidance](usage-guidance)
 - [Creating Service Accounts](service-accounts)
 - [Best Practices](best-practices)
 - [Frequently Asked Questions](end-user-faq)

--- a/usage-guidance.markdown
+++ b/usage-guidance.markdown
@@ -1,0 +1,56 @@
+---
+layout: page
+title: Github Usage Guidance
+permalink: usage-guidance
+---
+While it depends on the use case, our GitHub Enterprise license is often better
+suited for use by university administrative units than for teaching and
+learning purposes.
+
+Though there are a number of benefits included with our [Enterprise
+plan][enterprise-plan], such as free GitHub Actions minutes for private
+repositories, there are also limitations. For example, our license does not
+include certain features like Codespaces (virtual developer environments),
+GitHub Copilot (AI coding assistance), and GitHub Classroom.
+
+Students and faculty, however, can [register directly with
+GitHub][github-education-apply] and receive free access to these and other
+tools for coding, teaching, and learning. To learn more, visit [Explore the
+benefits of teaching and learning with GitHub
+Education][github-education-benefits].
+
+Note that our institution is not participating in the GitHub Campus Program.
+
+## Codespaces and Copilot
+Keep in mind that free, personal GitHub accounts can use Codespaces compute and
+storage resources up to a certain amount without being charged. See GitHub's
+[Codespaces pricing][codespaces-pricing] documentation for details.
+
+For staff, we are currently unable to support Codespaces and Copilot
+subscriptions managed and billed through our enterprise license. However,
+individual GitHub users can upgrade to a paid plan (for Codespaces) and/or
+[purchase Copilot as an individual][copilot-plans], and then use these features
+when working on repositories within our enterprise.
+
+Students and teachers who have registered with GitHub and individuals who have
+paid for these features can use them when working on repositories within our
+enterprise license.[^1] Of course, it's also fine to use these features in
+personally-owned repositories or repositories that are part of an organization
+outside our enterprise.
+
+[^1]: This depends on organization settings.
+
+## Questions?
+The GitHub Enterprise license is shared among all the CU campuses and usage and
+practices may differ.  Please reach out to your campus GitHub administrators or
+organization owner with questions.
+
+CU Boulder users can [create a support case for Platform
+Engineering][ucb-support].
+
+[codespaces-pricing]: https://github.com/features/codespaces#pricing
+[copilot-plans]: https://github.com/features/copilot/plans
+[enterprise-plan]:https://docs.github.com/en/get-started/learning-about-github/githubs-plans#github-enterprise
+[github-education-apply]: https://education.github.com/discount_requests/application
+[github-education-benfits]: https://docs.github.com/en/education/explore-the-benefits-of-teaching-and-learning-with-github-education
+[ucb-support]: mailto:oithelp@colorado.edu?subject=[GitHub]%20Route%20to%20Platform%20Engineering


### PR DESCRIPTION
Attempting to add guidance to help users discern whether using our enterprise license is the right fit for teaching and learning purposes. These updates also attempt to address usage of paid features that are difficult to track and bill for with a shared usage model. Recommendations are provided for GitHub Copilot and Codespaces that should keep admin overhead at a minimum.