### PR TITLE
Various updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "University-of-Colorado.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
+markdown: GFM
 theme: minima
 plugins:
   - jekyll-feed

--- a/index.markdown
+++ b/index.markdown
@@ -7,7 +7,7 @@ permalink: /
 This site hosts the documentation for the University of Colorado's GitHub Enterprise agreement. Each campus manages it's own GitHub organization, however the core of GitHub Enterprise is managed by the Platform Engineering team at the University of Colorado Boulder. If you wish to contact the Platform Engineering team please [email us](mailto:help@colorado.edu?subject=[GitHub]%20Route%20to%20Platform%20Engineering).
 
 ## For End Users
-- [Usage Guidance](usage-guidance)
+- [Usage Guidance](usage-guidance) (includes information about GitHub Copilot and Codespaces)
 - [Creating Service Accounts](service-accounts)
 - [Best Practices](best-practices)
 - [Frequently Asked Questions](end-user-faq)

--- a/usage-guidance.markdown
+++ b/usage-guidance.markdown
@@ -35,12 +35,29 @@ when working on repositories within our enterprise.
 In general, students and teachers who have registered with GitHub and
 individuals who have paid for these features can use them when working on
 repositories within our enterprise license. However, this may depend on
-organization settings - see the [Questions][#questions?] section below if you
+organization settings - see the [Questions](#questions) section below if you
 are unsure about this.
 
 Of course, it's also fine to use these features in personally-owned
 repositories or repositories that are part of an organization outside our
 enterprise.
+
+### Caution
+
+As an artificial intelligence (AI) tool, caution is required when using
+GitHub Copilot - careful steps may need to be taken to ensure that you
+understand how it integrates with your environment, makes coding suggestions,
+and whether content from your repository may be automatically shared with
+GitHub. This can be complicated.
+
+See the following GitHub documentation pages for additional details:
+
+  - [Configuring GitHub Copilot in your environment][configure-environment-copilot]
+  - [Excluding content from GitHub Copilot][excluding-content-copilot]
+
+Also, please refer to the CU System [Guidance for Artificial Intelligence
+Tools Use][cu-ai-guidance] web page and additional AI guidance and security
+resources for your specific CU campus.
 
 ## Questions?
 The GitHub Enterprise license is shared among all the CU campuses. Please reach
@@ -50,8 +67,11 @@ CU Boulder users can [create a support case for the OIT Platform Engineering
 team][ucb-support].
 
 [codespaces-pricing]: https://github.com/features/codespaces#pricing
+[configure-environment-copilot]: https://docs.github.com/en/copilot/managing-copilot/configure-personal-settings/configuring-github-copilot-in-your-environment
 [copilot-plans]: https://github.com/features/copilot/plans
+[cu-ai-guidance]: https://www.cu.edu/service-desk/how-guides/guidance-artificial-intelligence-tools-use
 [enterprise-plan]:https://docs.github.com/en/get-started/learning-about-github/githubs-plans#github-enterprise
+[excluding-content-copilot]: https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/setting-policies-for-copilot-in-your-organization/excluding-content-from-github-copilot
 [github-education-apply]: https://education.github.com/discount_requests/application
-[github-education-benfits]: https://docs.github.com/en/education/explore-the-benefits-of-teaching-and-learning-with-github-education
+[github-education-benefits]: https://docs.github.com/en/education/explore-the-benefits-of-teaching-and-learning-with-github-education
 [ucb-support]: mailto:oithelp@colorado.edu?subject=[GitHub]%20Route%20to%20Platform%20Engineering


### PR DESCRIPTION
These updates were inspired by a ServiceNow support case this week and some new information I recently learned from GitHub about extra care that needs to be taken when people decide to use GitHub Copilot (related to code suggestions, telemetry, etc.).

If we were enabling/allowing GitHub Copilot for Business via our GitHub Enterprise license, we could enforce some things at that level. However, since we are essentially telling users they are on their own with regard to this tool, we want to make sure they take precautions and learn about what is happening with their development environment and with potential sharing of repository data with GitHub.

Changes are as follows:

* Set GitHub Flavored Markdown (GFM) as the markdown processor (I was hoping this might allow me to add some alert boxes like warning, info, etc. but that didn't work and figuring it out is too much of a rabbit hole at the moment. That being said, it seems reasonable to leave this set to GFM.)

* Link fixes on the usage guidance page (it's helpful to note that when linking to another section within a page, you have to strip certain characters, like the question mark on the "Questions?" section).

* Modified the Usage Guidance page to include cautionary notes and links about GitHub Copilot and the use of AI tools.